### PR TITLE
Add support for absolute paths with `@import` 

### DIFF
--- a/lib/plugin/compile-less.js
+++ b/lib/plugin/compile-less.js
@@ -17,11 +17,11 @@ var parseAutoprefixerOptions = function(options) {
     }
   }
   catch (e) {
-    console.log("\n less-autoprefixer: invalid JSON format in AUTOPREFIXER_OPTIONS -", e)
+    console.log("\n less-autoprefixer: invalid JSON format in AUTOPREFIXER_OPTIONS -", e);
     console.log(' less-autoprefixer: falling back to default options - { browsers: "> 1%, last 2 versions, Firefox ESR, Opera 12.1"}, more info - https://github.com/postcss/autoprefixer-core#usage');
   }
   return {};
-}
+};
 
 var getAutoprefixerPlugin = function() {
   if (autoprefixerPlugin) {
@@ -30,14 +30,13 @@ var getAutoprefixerPlugin = function() {
   var options = {};
   if (process.env.AUTOPREFIXER_OPTIONS) {
     options = parseAutoprefixerOptions(process.env.AUTOPREFIXER_OPTIONS);
-  };
+  }
   autoprefixerPlugin = new LessPluginAutoprefixer(options);
   return autoprefixerPlugin;
-}
+};
 
 Plugin.registerSourceHandler("less", {archMatching: 'web'}, function (compileStep) {
   var source = compileStep.read().toString('utf8');
-  var sourceMap = null;
   var options = {
     filename: compileStep.inputPath,
     syncImport: true,
@@ -46,10 +45,9 @@ Plugin.registerSourceHandler("less", {archMatching: 'web'}, function (compileSte
   };
 
   try {
-    var output = null;
     var renderFuture = new Future();
     less.render(source, options, renderFuture.resolver());
-    output = renderFuture.wait();
+    var output = renderFuture.wait();
     if (output.css) {
       compileStep.addStylesheet({
         path: compileStep.inputPath + ".css",
@@ -63,9 +61,7 @@ Plugin.registerSourceHandler("less", {archMatching: 'web'}, function (compileSte
       sourcePath: error.filename || compileStep.inputPath,
       line: error.line,
       column: error.column + 1
-
     });
-    return;
   }
 });
 

--- a/lib/plugin/compile-less.js
+++ b/lib/plugin/compile-less.js
@@ -37,10 +37,25 @@ var getAutoprefixerPlugin = function() {
 
 Plugin.registerSourceHandler("less", {archMatching: 'web'}, function (compileStep) {
   var source = compileStep.read().toString('utf8');
+
+  // add the meteor project root-dir to the import path
+  // this allows packages to import files with ABSOLUTE paths like `/packages/bootstrap-custom/variables.less`
+
+  // inputPath => path relative to Project directory OR Package directory
+  // fullInputPath => absolute path of file
+  var rootDir = compileStep._fullInputPath.slice(0, -1 * compileStep.inputPath.length);
+  if (compileStep.packageName != null){
+    // except we're in /packages/package-name, so go up two folders.
+    rootDir = path.dirname(path.dirname(rootDir));
+  }
+
   var options = {
     filename: compileStep.inputPath,
     syncImport: true,
-    paths: [path.dirname(compileStep._fullInputPath)], // for @import
+    paths: [ // for @import
+      path.dirname(compileStep._fullInputPath),
+      rootDir
+    ],
     plugins: [getAutoprefixerPlugin()]
   };
 

--- a/package.js
+++ b/package.js
@@ -1,5 +1,7 @@
+var packageName = 'flemay:less-autoprefixer';
+
 Package.describe({
-  name: 'flemay:less-autoprefixer',
+  name: packageName,
   version: '1.0.2',
   summary: 'The dynamic stylesheet language + Autoprefixer',
   git: 'https://github.com/flemay/less-autoprefixer',
@@ -19,7 +21,7 @@ Package.registerBuildPlugin({
 });
 
 Package.onTest(function(api) {
-  api.use(['flemay:less-autoprefixer', 'test-helpers', 'tinytest', 'templating']);
+  api.use([packageName, 'test-helpers', 'tinytest', 'templating']);
   api.add_files(['test/less_tests.less', 'test/less_tests.js', 'test/less_tests.html',
     'test/less_tests_empty.less', 'test/autoprefixer_tests.import.less'
   ], 'client');

--- a/package.js
+++ b/package.js
@@ -15,7 +15,7 @@ Package.registerBuildPlugin({
     'lib/plugin/compile-less.js'
   ],
   npmDependencies: {
-    "less": "2.4.0",
+    "less": "2.5.1",
     "less-plugin-autoprefix": "1.4.2"
   }
 });


### PR DESCRIPTION
Hi,

The current `less` package supports absolute paths for imports (at least from packages).

I've been using a local fork with this modification for a while, and thought you may want to merge it in to your package.